### PR TITLE
ACL clarification and some code polishing

### DIFF
--- a/app/settings.php
+++ b/app/settings.php
@@ -1,4 +1,7 @@
 <?php
+
+use App\Common\Acl;
+
 return [
     'settings' => [
         // Slim Settings
@@ -20,26 +23,36 @@ return [
         // ACL
         'acl' => [
             'default_role' => 'guest',
+
             'roles' => [
+                // role => [parents]
                 'guest' => [],
                 'user'  => ['guest'],
                 'admin' => ['user'],
             ],
+
             /**
              * just a list of generic resources for manual checking
              * specified here so can be used in the code if needs be
              * Example: ['user' => null]
              */
-            'resources' => [],
+            'resources' => [
+                // resource => parent
+            ],
+
             // where we specify the guarding!
             'guards' => [
+
                 /**
                  * list of resource to roles to permissions
                  * optional
                  * if included all resources default to deny unless specified.
                  * Example: ['user', ['admin']]
                  */
-                'resources' => [],
+                Acl::GUARD_TYPE_RESOURCE => [
+
+                ],
+
                 /**
                  * list of literal routes for guarding.
                  * optional
@@ -47,10 +60,12 @@ return [
                  * Similar format to resource 'resource' route, roles, 'permission' action
                  * ['route', ['roles'], ['methods',' methods1']]
                  */
-                'routes' => [
-                    ['/api/token', ['guest'], ['post']],
-                    ['/api/user', ['user'], ['get']],
+                Acl::GUARD_TYPE_ROUTE => [
+                    // resource, roles, privileges
+                    ['/api/token', ['guest'], [Acl::PRIVILEGE_POST]],
+                    ['/api/user',  ['user'],  [Acl::PRIVILEGE_GET]],
                 ],
+
                 /**
                  * list of callables to resolve against
                  * optional
@@ -58,7 +73,8 @@ return [
                  * 'permission' section is combined into the callable section
                  * ['callable', ['roles']]
                  */
-                'callables' => [
+                Acl::GUARD_TYPE_CALLABLE => [
+                    // resource, roles, privileges
                     ['App\Controller\CrudController',              ['user']],
                     ['App\Controller\CrudController:actionIndex',  ['user']],
                     ['App\Controller\CrudController:actionGet',    ['user']],
@@ -76,18 +92,20 @@ return [
         ],
 
         'encoder' => [
-            'default' => [
-                'App\Model\Log'   => 'App\Schema\LogSchema',
-                'App\Model\Right' => 'App\Schema\RightSchema',
-                'App\Model\Role'  => 'App\Schema\RoleSchema',
-                'App\Model\User'  => 'App\Schema\UserSchema',
+            'schemas' => [
+                'default' => [
+                    'App\Model\Log'   => 'App\Schema\LogSchema',
+                    'App\Model\Right' => 'App\Schema\RightSchema',
+                    'App\Model\Role'  => 'App\Schema\RoleSchema',
+                    'App\Model\User'  => 'App\Schema\UserSchema',
+                ],
+                'extended' => [
+                    'App\Model\Log'   => 'App\Schema\LogSchema',
+                    'App\Model\Right' => 'App\Schema\RightSchema',
+                    'App\Model\Role'  => 'App\Schema\RoleSchema',
+                    'App\Model\User'  => 'App\Schema\UserSchemaExtended',
+                ],
             ],
-            'extended' => [
-                'App\Model\Log'   => 'App\Schema\LogSchema',
-                'App\Model\Right' => 'App\Schema\RightSchema',
-                'App\Model\Role'  => 'App\Schema\RoleSchema',
-                'App\Model\User'  => 'App\Schema\UserSchemaExtended',
-            ]
         ],
 
         'translate' => [

--- a/app/src/Common/Acl.php
+++ b/app/src/Common/Acl.php
@@ -7,45 +7,174 @@ use Zend\Permissions\Acl\Resource\GenericResource as GenericResource;
 
 final class Acl extends ZendAcl
 {
+    /**
+     * @var string privilege to make POST request to the specified resource
+     */
+    const PRIVILEGE_POST = 'post';
+
+    /**
+     * @var string privilege to mekt GET request to the specified resource
+     */
+    const PRIVILEGE_GET = 'get';
+
+    /**
+     * @var string guard can be applied to resources
+     */
+    const GUARD_TYPE_RESOURCE = 'resources';
+
+    /**
+     * @var string guard can be applied to routes
+     */
+    const GUARD_TYPE_ROUTE = 'routes';
+
+    /**
+     * @var guard can be applied to callables
+     */
+    const GUARD_TYPE_CALLABLE = 'callables';
+
+    /**
+     * Acl constructor.
+     *
+     * @param $configuration ACL configuration - see app settings ACL section
+     * @throws \Exception
+     */
     public function __construct($configuration)
     {
         // setup roles
         foreach ($configuration['roles'] as $role => $parents) {
             $this->addRole(new GenericRole($role), $parents);
         }
+
         // setup resources
         if (array_key_exists('resources', $configuration)) {
             foreach ($configuration['resources'] as $resource => $parent) {
+                // create resource
                 $this->addResource(new GenericResource($resource), $parent);
             }
         }
+
+        // setup guards
         foreach ($configuration['guards'] as $guardType => $guardRules) {
-            if (!in_array($guardType, ['resources', 'routes', 'callables'])) {
-                throw new \Exception('Error Processing Request');
-            }
             foreach ($guardRules as $rule) {
-                if ('callables' === $guardType && 2 !== count($rule)) {
-                    throw new \Exception('Error Processing Request');
-                }
-                if ('callables' !== $guardType && 3 !== count($rule)) {
-                    if (('resources' === $guardType && 2 !== count($rule)) || 'routes' === $guardType) {
-                        throw new \Exception('Error Processing Request');
-                    } else {
-                        $rule[] = null;
-                    }
-                }
-                list($resource, $roles) = $rule;
-                $privileges = (3 === count($rule) ? $rule[2] : null);
-                if ('callables' === $guardType) {
-                    $resource = 'callable/'.$resource;
+                // parse rule into parts
+                list($resource, $roles, $privileges) = $this->parseRule($guardType, $rule);
+
+                if ($guardType != static::GUARD_TYPE_RESOURCE) {
+                    // resources were already build earlier
+                    $resource = static::buildResourceName($guardType, $resource);
                     $this->addResource(new GenericResource($resource));
-                } elseif ('routes' === $guardType) {
-                    $resource = 'route'.$resource;
-                    $this->addResource(new GenericResource($resource));
-                    $privileges = array_map('strtolower', $privileges);
                 }
+
+                // allow access to this resource
                 $this->allow($roles, $resource, $privileges);
             }
         }
+    }
+
+    /**
+     * Verify guard rule correctness
+     *
+     * @param $guardType
+     * @param array $rule
+     * @return bool
+     * @throws \Exception
+     */
+    protected function verifyRule($guardType, array $rule)
+    {
+        switch ($guardType) {
+            case static::GUARD_TYPE_RESOURCE:
+                // resources guards must have 2 parts
+
+            case static::GUARD_TYPE_CALLABLE:
+                // callables guards must have 2 parts
+                // 'callables' => [
+                //    // resource, roles, privileges
+                //    ['App\Controller\CrudController',              ['user']],
+                //    ['App\Controller\CrudController:actionIndex',  ['user']],
+                if (count($rule) == 2) {
+                    // all OK
+                    return true;
+                }
+                break;
+
+            case static::GUARD_TYPE_ROUTE:
+                // routes guards must have 3 parts
+                // 'routes' => [
+                // // resource, roles, privileges
+                // ['/api/token', ['guest'], ['post']],
+                // ['/api/user',  ['user'],  ['get']],
+                if (count($rule) == 3) {
+                    // all OK
+                    return true;
+                }
+                break;
+        }
+
+        // unknown guard type or incorrect rule structure
+        throw new \Exception('Error Processing Request');
+    }
+
+    /**
+     * Parse rule description into separate parts
+     *
+     * @param $guardType
+     * @param $rule
+     * @return array
+     */
+    protected function parseRule($guardType, $rule)
+    {
+        $this->verifyRule($guardType, $rule);
+
+        // resource name is located in $rule[0]
+        // roles array is located in $rule[1]
+        // privileges are located in $rule[2]
+        // return lower-cased array of privileges
+
+        $resource   = $rule[0];
+        $roles      = $rule[1];
+        $privileges = count($rule) == 3 ? array_map('strtolower', $rule[2]) : null;
+
+        return [$resource, $roles, $privileges];
+    }
+
+    /**
+     * Build name of the resource based on guard type
+     *
+     * @param $guardType guard type
+     * @param $base base part of the resource name to be built
+     * @return string ready resource name
+     * @throws \Exception
+     */
+    public static function buildResourceName($guardType, $base)
+    {
+        switch ($guardType) {
+            case static::GUARD_TYPE_CALLABLE:
+                return "callable//$base";
+
+            case static::GUARD_TYPE_ROUTE:
+                return "route//$base";
+        }
+
+        // unknown guard type
+        throw new \Exception('Error Processing Request');
+    }
+
+    /**
+     * Get one of PRIVILEGE_XXX constants based on HTTP method - GET, POST, PUT, etc
+     *
+     * @param $method HTTP method GET, POST, PUT, etc
+     * @return null|string
+     */
+    public static function getPrivilegeByHTTPMethod($method)
+    {
+        switch (strtolower($method)) {
+            case 'post':
+                return static::PRIVILEGE_POST;
+
+            case 'get':
+                return static::PRIVILEGE_GET;
+        }
+
+        return null;
     }
 }

--- a/app/src/Common/ApiRenderer.php
+++ b/app/src/Common/ApiRenderer.php
@@ -3,7 +3,7 @@ namespace App\Common;
 
 use Psr\Http\Message\ResponseInterface as Response;
 
-final class Renderer
+final class ApiRenderer
 {
     /**
      * @var
@@ -27,9 +27,9 @@ final class Renderer
      *
      * @return Response
      */
-    public function jsonApiRender(Response $response, $statusCode = 200, $data = '')
+    public function jsonResponse(Response $response, $statusCode = 200, $data = '')
     {
-        $jsonApiResponse = $response
+        $jsonResponse = $response
             ->withHeader('Access-Control-Allow-Origin', '*')
             ->withHeader('Access-Control-Allow-Methods', 'GET, PUT, PATCH, POST, DELETE, OPTIONS')
             ->withHeader('Access-Control-Allow-Credentials', 'true')
@@ -37,8 +37,8 @@ final class Renderer
             ->withHeader('Content-Type', 'application/vnd.api+json')
             ->withStatus($statusCode);
 
-        $jsonApiResponse->getBody()->write($data);
+        $jsonResponse->getBody()->write($data);
 
-        return $jsonApiResponse;
+        return $jsonResponse;
     }
 }

--- a/app/src/Common/Auth.php
+++ b/app/src/Common/Auth.php
@@ -6,6 +6,11 @@ use App\Model\User;
 final class Auth
 {
     /**
+     * @var User
+     */
+    private static $user = null;
+
+    /**
      * Forbidden to create new instances
      */
     private function __construct()
@@ -20,11 +25,6 @@ final class Auth
     {
 
     }
-
-    /**
-     * @var User
-     */
-    private static $user = null;
 
     /**
      * @param User $user

--- a/app/src/Common/JsonApiEncoder.php
+++ b/app/src/Common/JsonApiEncoder.php
@@ -34,17 +34,17 @@ final class JsonApiEncoder
      */
     public function encode(Request $request, $entities, $pageNumber = null, $pageSize = null)
     {
-        $factory        = new Factory();
-        $parameters     = $factory->createQueryParametersParser()->parse($request);
-        $user           = Auth::getUser();
-        $encodeEntities = $this->settings['encoder']['default'];
+        $factory    = new Factory();
+        $parameters = $factory->createQueryParametersParser()->parse($request);
+        $user       = Auth::getUser();
+        $schemas    = $this->settings['encoder']['schemas']['default'];
 
         if ($user && $user->role_id == User::ROLE_ADMIN) {
-            $encodeEntities = $this->settings['encoder']['extended'];
+            $schemas = $this->settings['encoder']['schemas']['extended'];
         }
 
         $encoder = Encoder::instance(
-            $encodeEntities,
+            $schemas,
             new EncoderOptions(
                 JSON_PRETTY_PRINT,
                 $this->settings['params']['host'].'/api'

--- a/app/src/Common/MailRenderer.php
+++ b/app/src/Common/MailRenderer.php
@@ -41,7 +41,7 @@ class MailRenderer
         }
 
         if (!is_file($this->templatePath.$template)) {
-            throw new \RuntimeException('View cannot render `$template` because the template does not exist');
+            throw new \RuntimeException("View cannot render template `$template` because it does not exist");
         }
 
         $data = array_merge($this->attributes, $data);

--- a/app/src/Controller/BaseController.php
+++ b/app/src/Controller/BaseController.php
@@ -19,9 +19,9 @@ abstract class BaseController
     public $encoder;
 
     /**
-     * @var \App\Common\Renderer
+     * @var \App\Common\ApiRenderer
      */
-    public $renderer;
+    public $apiRenderer;
 
     /**
      * @var array
@@ -45,7 +45,7 @@ abstract class BaseController
      */
     public function __construct($container)
     {
-        $this->renderer     = $container['renderer'];
+        $this->apiRenderer  = $container['apiRenderer'];
         $this->validation   = $container['validation'];
         $this->settings     = $container['settings'];
         $this->mailer       = $container['mailer'];
@@ -63,10 +63,10 @@ abstract class BaseController
      * @return bool
      * @throws JsonException
      */
-    public function validationRequest($params, $entity, $request)
+    public function validateRequestParams($params, $entity, $request)
     {
         if (!isset($params['data']['attributes'])) {
-            throw new JsonException($entity, 400, 'Invalid Attribute', 'Do not see required attributes - data.');
+            throw new JsonException($entity, 400, 'Invalid Attribute', 'Do not see required attribute - data.');
         }
 
         $validator = $this->validation->make($params['data']['attributes'], $request->rules());

--- a/app/src/Controller/CrudController.php
+++ b/app/src/Controller/CrudController.php
@@ -80,7 +80,7 @@ class CrudController extends BaseController
 
         $result = $this->encoder->encode($request, $entities, $pageNumber, $pageSize);
 
-        return $this->renderer->jsonApiRender($response, 200, $result);
+        return $this->apiRenderer->jsonResponse($response, 200, $result);
     }
 
     /**
@@ -103,7 +103,7 @@ class CrudController extends BaseController
 
         $result = $this->encoder->encode($request, $entity);
 
-        return $this->renderer->jsonApiRender($response, 200, $result);
+        return $this->apiRenderer->jsonResponse($response, 200, $result);
     }
 
     /**
@@ -120,12 +120,12 @@ class CrudController extends BaseController
         $requestClass = 'App\Requests\\'.Helper::dashesToCamelCase($args['entity'], true).'CreateRequest';
         $params       = $request->getParsedBody();
 
-        $this->validationRequest($params, $args['entity'], new $requestClass());
+        $this->validateRequestParams($params, $args['entity'], new $requestClass());
 
         $entity = $modelName::create($params['data']['attributes']);
         $result = $this->encoder->encode($request, $entity);
 
-        return $this->renderer->jsonApiRender($response, 200, $result);
+        return $this->apiRenderer->jsonResponse($response, 200, $result);
 
     }
 
@@ -149,13 +149,13 @@ class CrudController extends BaseController
             throw new JsonException($args['entity'], 404, 'Not found', 'Entity not found');
         }
 
-        $this->validationRequest($params, $args['entity'], new $requestClass());
+        $this->validateRequestParams($params, $args['entity'], new $requestClass());
 
         $entity->update($params['data']['attributes']);
 
         $result = $this->encoder->encode($request, $entity);
 
-        return $this->renderer->jsonApiRender($response, 200, $result);
+        return $this->apiRenderer->jsonResponse($response, 200, $result);
     }
 
     /**
@@ -179,7 +179,7 @@ class CrudController extends BaseController
         $entity->delete();
 
         // return 204 No Content as successful result
-        return $this->renderer->jsonApiRender($response, 204);
+        return $this->apiRenderer->jsonResponse($response, 204);
     }
 
 }

--- a/app/src/Controller/TokenController.php
+++ b/app/src/Controller/TokenController.php
@@ -63,7 +63,7 @@ final class TokenController extends BaseController
     {
         $params = $request->getParsedBody();
 
-        $this->validationRequest($params, 'token', new GetTokenRequest());
+        $this->validateRequestParams($params, 'token', new GetTokenRequest());
 
         $user = User::findUserByEmail($params['data']['attributes']['username']);
 
@@ -80,7 +80,7 @@ final class TokenController extends BaseController
 
         $result = $this->buildResponse($accessToken, $refreshToken);
 
-        return $this->renderer->jsonApiRender($response, 200, json_encode($result));
+        return $this->apiRenderer->jsonResponse($response, 200, json_encode($result));
     }
 
     /**
@@ -126,7 +126,7 @@ final class TokenController extends BaseController
     {
         $params = $request->getParsedBody();
 
-        $this->validationRequest($params, 'token', new RefreshTokenRequest());
+        $this->validateRequestParams($params, 'token', new RefreshTokenRequest());
 
         $user = RefreshToken::getUserByToken($params['data']['attributes']['refresh_token']);
 
@@ -143,7 +143,7 @@ final class TokenController extends BaseController
 
         $result = $this->buildResponse($token, $refreshToken);
 
-        return $this->renderer->jsonApiRender($response, 200, json_encode($result));
+        return $this->apiRenderer->jsonResponse($response, 200, json_encode($result));
     }
 
     /**

--- a/app/src/Controller/UserController.php
+++ b/app/src/Controller/UserController.php
@@ -24,7 +24,7 @@ final class UserController extends CrudController
     {
         $params = $request->getParsedBody();
 
-        $this->validationRequest($params, $args['entity'], new UserCreateRequest());
+        $this->validateRequestParams($params, $args['entity'], new UserCreateRequest());
 
         $exist = User::exist($params['data']['attributes']['email']);
 
@@ -38,7 +38,7 @@ final class UserController extends CrudController
 
         $result = $this->encoder->encode($request, $user);
 
-        return $this->renderer->jsonApiRender($response, 200, $result);
+        return $this->apiRenderer->jsonResponse($response, 200, $result);
     }
 
     /**
@@ -59,7 +59,7 @@ final class UserController extends CrudController
 
         $params = $request->getParsedBody();
 
-        $this->validationRequest($params, $args['entity'], new UserUpdateRequest());
+        $this->validateRequestParams($params, $args['entity'], new UserUpdateRequest());
 
         $user->update($params['data']['attributes']);
 
@@ -70,7 +70,7 @@ final class UserController extends CrudController
 
         $result = $this->encoder->encode($request, $user);
 
-        return $this->renderer->jsonApiRender($response, 200, $result);
+        return $this->apiRenderer->jsonResponse($response, 200, $result);
     }
 
     /**
@@ -85,7 +85,7 @@ final class UserController extends CrudController
     {
         $params = $request->getParsedBody();
 
-        $this->validationRequest($params, $args['entity'], new RequestPasswordResetRequest());
+        $this->validateRequestParams($params, $args['entity'], new RequestPasswordResetRequest());
 
         $user = User::findUserByEmail($params['data']['attributes']['email']);
 
@@ -113,7 +113,7 @@ final class UserController extends CrudController
             ), 'text/html');
 
         if ($this->mailer->send($message)) {
-            return $this->renderer->jsonApiRender($response, 204);
+            return $this->apiRenderer->jsonResponse($response, 204);
         };
 
         throw new JsonException($args['entity'], 400, 'Bad request', 'Bad request');
@@ -131,7 +131,7 @@ final class UserController extends CrudController
     {
         $params = $request->getParsedBody();
 
-        $this->validationRequest($params, $args['entity'], new PasswordResetRequest());
+        $this->validateRequestParams($params, $args['entity'], new PasswordResetRequest());
 
         $user = User::findByPasswordResetToken($params['data']['attributes']['token']);
 
@@ -140,7 +140,7 @@ final class UserController extends CrudController
             $user->removePasswordResetToken();
 
             if ($user->save()) {
-                return $this->renderer->jsonApiRender($response, 204);
+                return $this->apiRenderer->jsonResponse($response, 204);
             };
         }
 

--- a/app/src/Middleware/CustomException.php
+++ b/app/src/Middleware/CustomException.php
@@ -3,7 +3,7 @@
 namespace App\Middleware;
 
 use App\Common\JsonException;
-use App\Common\Renderer;
+use App\Common\ApiRenderer;
 
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -11,16 +11,16 @@ use Psr\Http\Message\ResponseInterface;
 class CustomException
 {
     /**
-     * @var Renderer
+     * @var ApiRenderer
      */
     private $renderer;
 
     /**
      * CustomException constructor.
      *
-     * @param Renderer $renderer
+     * @param ApiRenderer $renderer
      */
-    public function __construct(Renderer $renderer)
+    public function __construct(ApiRenderer $renderer)
     {
         $this->renderer = $renderer;
     }
@@ -37,7 +37,7 @@ class CustomException
         try {
             return $next($request, $response);
         } catch (JsonException $e) {
-            return $this->renderer->jsonApiRender($response, $e->statusCode, $e->encodeError());
+            return $this->renderer->jsonResponse($response, $e->statusCode, $e->encodeError());
         }
     }
 }

--- a/app/src/Providers/DatabaseServiceProvider.php
+++ b/app/src/Providers/DatabaseServiceProvider.php
@@ -17,11 +17,11 @@ final class DatabaseServiceProvider extends BaseServiceProvider
     public function register(Container $container)
     {
         $config  = $container['settings'];
-        $capsule = new Capsule;
+        $capsule = new Capsule();
         foreach ($config['database']['connections'] as $name => $connection) {
             $capsule->addConnection($connection, $name);
         }
-        $capsule->setEventDispatcher(new Dispatcher(new IlluminateContainer));
+        $capsule->setEventDispatcher(new Dispatcher(new IlluminateContainer()));
         $capsule->setAsGlobal();
         $capsule->bootEloquent();
 

--- a/app/src/Providers/ErrorHandlerServiceProvider.php
+++ b/app/src/Providers/ErrorHandlerServiceProvider.php
@@ -19,7 +19,7 @@ final class ErrorHandlerServiceProvider extends BaseServiceProvider
                 $details = (defined('DEBUG_MODE') && DEBUG_MODE == 1) ? $exception->getMessage() : 'Internal server error';
                 $error   = new JsonException(null, 500, 'Internal server error', $details);
 
-                return $container->get('renderer')->jsonApiRender($response, $error->statusCode, $error->encodeError());
+                return $container->get('apiRenderer')->jsonResponse($response, $error->statusCode, $error->encodeError());
             };
         };
 

--- a/app/src/Providers/RendererServiceProvider.php
+++ b/app/src/Providers/RendererServiceProvider.php
@@ -3,7 +3,7 @@
 namespace App\Providers;
 
 use Pimple\Container;
-use App\Common\Renderer;
+use App\Common\ApiRenderer;
 use App\Common\MailRenderer;
 
 final class RendererServiceProvider extends BaseServiceProvider
@@ -17,8 +17,8 @@ final class RendererServiceProvider extends BaseServiceProvider
     {
         $config = $container['settings'];
 
-        $container['renderer'] = function() use ($config) {
-            $renderer = new Renderer($config);
+        $container['apiRenderer'] = function() use ($config) {
+            $renderer = new ApiRenderer($config);
 
             return $renderer;
         };

--- a/app/src/Providers/ValidationServiceProvider.php
+++ b/app/src/Providers/ValidationServiceProvider.php
@@ -22,7 +22,7 @@ final class ValidationServiceProvider extends BaseServiceProvider
 
         // translation
         $container['translator'] = function() use ($config) {
-            $translateFileLoader = new FileLoader(new Filesystem, $config['translate']['path']);
+            $translateFileLoader = new FileLoader(new Filesystem(), $config['translate']['path']);
             $translator          = new Translator($translateFileLoader, $config['translate']['locale']);
 
             return $translator;

--- a/mail/RequestPasswordReset.php
+++ b/mail/RequestPasswordReset.php
@@ -3,6 +3,6 @@
 <head>
 </head>
 <body>
-    <a href="<?= $host; ?>/password-reset?token=<?= $token; ?>">Ссылка для восстановления пароля</a>
+    <a href="<?=$host?>/password-reset?token=<?=$token?>">Ссылка для восстановления пароля</a>
 </body>
 </html>

--- a/public/index.php
+++ b/public/index.php
@@ -42,7 +42,7 @@ $app = new \Slim\App($container);
 
 // Register middleware
 $app->add(new \App\Middleware\Logger($app->getContainer()->get('logger')));
-$app->add(new \App\Middleware\CustomException($app->getContainer()->get('renderer')));
+$app->add(new \App\Middleware\CustomException($app->getContainer()->get('apiRenderer')));
 
 // Register routes
 require __DIR__.'/../app/routes.php';


### PR DESCRIPTION
Please, review the following modifications:

1. ACL clarification and simplification. All 'magic strings' turned into Acl::PRIVILEGE_XXX or Acl::GUARD_XXX contants. Request authorization processing made clearer due to detailed separation of entities, not related on the same spelling of different entities as 'POST' HTTP method or 'post' ACL privilege
2. Some code polishing - naming clarifications and unifications
